### PR TITLE
Attempt to avoid null island values by parsing the google maps URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,17 @@
         <p>Generate GPX and KMZ files from your Google Maps saved places to import as bookmarks in <a href="https://organicmaps.app/" target="_blank">Organic Maps</a>, or use anywhere you'd like. This tool generates everything locally in your browser and does not upload any data.</p>
         <p>You can retrieve a <code>Saved Places.json</code> file by navigating to "Your data in Maps" in your Google Account settings or by accessing <a href="https://myaccount.google.com/yourdata/maps" target="_blank">this page</a>, then pressing "Download your Maps data."</p>
         <p>Read about why Organic Maps is <a href="https://news.itsfoss.com/organic-maps/" target="_blank">the open-source offline map you need to ditch Google Maps</a>.</p>
+        <p>
+            The Google export may not provide latitude and longitude for every location (see <a href="https://github.com/rudokemper/google-maps-places-to-organic-maps/issues/2">Issue #2</a>). If the coordinates cannot be found within the data, you can opt-in to have the tool attempt to look up locations from addresses.
+        </p>
+        <p>
+            <label>
+                <input type="checkbox" id="addressGeocodeOptIn" name="addressGeocodeOptIn" value="consent">
+            
+                Attempt to look up locations from addresses using <a href="https://nominatim.openstreetmap.org" target="_blank">OSM Nominatim</a> for geocoding
+            </label>
+        </p>
+
         <form id="kmlForm" class="form-group">
             <label for="json">Select <code>Saved Places.json</code></label>
             <input type="file" id="json" name="json"><br>

--- a/index.html
+++ b/index.html
@@ -167,6 +167,7 @@
         </form>
 
         <p id="errorMessage"></p>
+        <p id="progress"></p>
 
         <a id="downloadGpxLink" class="downloadLink btn" style="display:none;">Download GPX</a>
         <a id="downloadKmzLink" class="downloadLink btn" style="display:none;">Download KMZ</a>

--- a/script/main.js
+++ b/script/main.js
@@ -179,6 +179,11 @@ function showErrorToUser(message) {
   document.getElementById("errorMessage").style.display = "block";
 }
 
+function showProgressToUser(message) {
+  document.getElementById("progress").textContent = message;
+  document.getElementById("progress").style.display = "block";
+}
+
 function generateFiles() {
   const geoJSONFile = document.getElementById("json").files[0];
   const reader = new FileReader();

--- a/script/main.js
+++ b/script/main.js
@@ -87,6 +87,13 @@ async function findLocationInURL(feature) {
   return feature;
 }
 
+/**
+ * The findLocationInURL function may not be able to find the coordinates in the URL. Sometimes it may only find the address.
+ * This function will attempt to look up the coordinates for the address in the location field if the coordinates are still missing (i.e. null island).
+ *
+ * @param {*} feature the feature to process
+ * @returns the feature, modified if necessary
+ */
 async function lookupMissingCoordsWithAddress(feature) {
 
   const properties = feature.properties;

--- a/script/main.js
+++ b/script/main.js
@@ -181,6 +181,7 @@ function processGeoJSONFeature(feature) {
 }
 
 function showErrorToUser(message) {
+  console.error(message);
   document.getElementById("errorMessage").textContent = message;
   document.getElementById("errorMessage").style.display = "block";
 }

--- a/script/main.js
+++ b/script/main.js
@@ -3,6 +3,26 @@ function convertTimestamp(timestamp) {
   return date.toLocaleString();
 }
 
+function parseCoordinates(string) {
+  // determine if a string is likely to be coordinates
+  // if it is, return the coordinates as an array, if not return undefined
+  let isCoordinates = true;
+
+  let parts = string.split(",")
+  // coordinates should have 2 parts
+  if (parts.length !== 2) {
+    isCoordinates = false;
+  }
+  // if any of the parts cant parse to a float, then its not coordinates
+  if (parts.some((coord) => isNaN(parseFloat(coord)))) {
+    isCoordinates = false;
+  }
+
+  if (isCoordinates) {
+    return parts.map(parseFloat);
+  }
+}
+
 function processGeoJSONFeatures(geoJSON) {
   geoJSON.features.forEach((feature) => {
     const properties = feature.properties;

--- a/script/main.js
+++ b/script/main.js
@@ -38,11 +38,18 @@ function processGeoJSONFeatures(geoJSON) {
       const url = new URL(google_maps_url);
       const searchParams = new URLSearchParams(url.search);
       const q = searchParams.get("q");
-      const coordinates = q.split(",");//.split("@")[1]
-      let long = parseFloat(coordinates[1]);
-      let lat = parseFloat(coordinates[0]);
-      console.log("Coordinates found: ", long, lat);
-      feature.geometry.coordinates = [long, lat];
+
+      if (!q) {
+        console.log("No coordinates found in google maps url, skipping");
+        // the q param isnt present, it likely contains the cid param instead, which might mean that the location is a business, but effectively menas that the properties.location field and the coordinates are already present in the data
+      } else {
+        // this is likely coordinates
+        const coordinates = q.split(",");//.split("@")[1]
+        let long = parseFloat(coordinates[1]);
+        let lat = parseFloat(coordinates[0]);
+        console.log("Coordinates found: ", long, lat);
+        feature.geometry.coordinates = [long, lat];
+      } 
     }
 
 

--- a/script/main.js
+++ b/script/main.js
@@ -70,7 +70,19 @@ async function findLocationInURL(feature) {
     let long, lat = coordinates;
     console.log("Coordinates found: ", long, lat);
     feature.geometry.coordinates = [long, lat];
-  } 
+  } else {
+    // this is likely a place name or address
+    console.log("Place name or address found: ", q);
+    // detect if this is likely to be an address
+    console.log("stripped place name", q.trim());
+    let address = q.trim();
+    //set the address and create any intermediate objects
+    if (!feature.properties.location) {
+      feature.properties.location = {};
+    }
+    feature.properties.location.address = address
+   
+  }
 
   return feature;
 }

--- a/script/main.js
+++ b/script/main.js
@@ -67,9 +67,7 @@ function fixupNullIslandCoordinates(feature) {
 
 function processGeoJSONFeatures(geoJSON) {
   geoJSON.features.forEach((feature) => {
-
-    feature = fixupNullIslandCoordinates(feature);
-
+    
     const properties = feature.properties;
     const { date, google_maps_url, location } = properties;
     let { address, name, Comment: comment } = location || {};

--- a/script/main.js
+++ b/script/main.js
@@ -174,6 +174,11 @@ function processGeoJSONFeature(feature) {
   return feature;
 }
 
+function showErrorToUser(message) {
+  document.getElementById("errorMessage").textContent = message;
+  document.getElementById("errorMessage").style.display = "block";
+}
+
 function generateFiles() {
   const geoJSONFile = document.getElementById("json").files[0];
   const reader = new FileReader();
@@ -184,9 +189,7 @@ function generateFiles() {
       geoJSON = JSON.parse(event.target.result);
       if (!geoJSON.features) throw new Error("Invalid GeoJSON file");
     } catch (error) {
-      document.getElementById("errorMessage").textContent =
-        "Invalid GeoJSON file. Please upload a valid file.";
-      document.getElementById("errorMessage").style.display = "block";
+      showErrorToUser("Invalid GeoJSON file. Please upload a valid file.");
       return;
     }
 

--- a/script/main.js
+++ b/script/main.js
@@ -22,7 +22,7 @@ function processGeoJSONFeatures(geoJSON) {
       let long = parseFloat(coordinates[1]);
       let lat = parseFloat(coordinates[0]);
       console.log("Coordinates found: ", long, lat);
-      feature.geometry.coordinates = [lat, long];
+      feature.geometry.coordinates = [long, lat];
     }
 
 

--- a/script/main.js
+++ b/script/main.js
@@ -87,6 +87,29 @@ async function findLocationInURL(feature) {
   return feature;
 }
 
+
+async function addressToCoordinates(address) {
+  return new Promise((resolve, reject) => {
+    fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&q=${address.replace(" ", "+")}&polygon=1&addressdetails=1`
+    )
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.length === 0) {
+          reject("No results found");
+        } else {
+          // TODO: we should also possibly return the name of the place
+          const { lat, lon } = data[0];
+          resolve([lon, lat]);
+        }
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+
+}
+
 function processGeoJSONFeature(feature) {
 
   const properties = feature.properties;

--- a/script/main.js
+++ b/script/main.js
@@ -9,6 +9,20 @@ function processGeoJSONFeatures(geoJSON) {
     const { date, google_maps_url, location } = properties;
     let { address, name, Comment: comment } = location || {};
 
+
+    //check if the geometry is a null island
+    if (feature.geometry.coordinates[0] === 0 && feature.geometry.coordinates[1] === 0) {
+      console.log("Null island found, trying to get coordinates from google maps url");
+
+      // parse the google maps url to get the coordinates
+      const url = new URL(google_maps_url);
+      const searchParams = new URLSearchParams(url.search);
+      const q = searchParams.get("q");
+      const coordinates = q.split(",");//.split("@")[1]
+      feature.geometry.coordinates = [parseFloat(coordinates[0]), parseFloat(coordinates[1])];
+    }
+
+
     // If name is not available, use address or coordinates
     properties.name =
       name ||

--- a/script/main.js
+++ b/script/main.js
@@ -6,21 +6,18 @@ function convertTimestamp(timestamp) {
 function parseCoordinates(string) {
   // determine if a string is likely to be coordinates
   // if it is, return the coordinates as an array, if not return undefined
-  let isCoordinates = true;
-
   let parts = string.split(",")
+
   // coordinates should have 2 parts
   if (parts.length !== 2) {
-    isCoordinates = false;
+    return [false, false];
   }
   // if any of the parts cant parse to a float, then its not coordinates
-  if (parts.some((coord) => isNaN(parseFloat(coord)))) {
-    isCoordinates = false;
+  if (parts.some((coord) => isNaN(parseFloat(coord.trim())))) {
+    return [false, false];
   }
 
-  if (isCoordinates) {
-    return parts.map(parseFloat);
-  }
+  return parts.map(parseFloat)
 }
 
 /**
@@ -64,10 +61,9 @@ async function findLocationInURL(feature) {
     return feature;
   }
   
-  const coordinates = parseCoordinates(q);
-  if (coordinates) {
+  let [long, lat] = parseCoordinates(q);
+  if (long && lat) {
     // this is likely coordinates
-    let long, lat = coordinates;
     console.log("Coordinates found: ", long, lat);
     feature.geometry.coordinates = [long, lat];
   } else {

--- a/script/main.js
+++ b/script/main.js
@@ -125,6 +125,7 @@ function generateFiles() {
 
     geoJSON.features = await Promise.all(
       geoJSON.features.map(async (feature) => {
+        feature = await findLocationInURL(feature);
         feature = await processGeoJSONFeature(feature);
         return feature;
       })

--- a/script/main.js
+++ b/script/main.js
@@ -12,14 +12,17 @@ function processGeoJSONFeatures(geoJSON) {
 
     //check if the geometry is a null island
     if (feature.geometry.coordinates[0] === 0 && feature.geometry.coordinates[1] === 0) {
-      console.log("Null island found, trying to get coordinates from google maps url");
+      console.log("Null island found, trying to get coordinates from google maps url: ", google_maps_url);
 
       // parse the google maps url to get the coordinates
       const url = new URL(google_maps_url);
       const searchParams = new URLSearchParams(url.search);
       const q = searchParams.get("q");
       const coordinates = q.split(",");//.split("@")[1]
-      feature.geometry.coordinates = [parseFloat(coordinates[0]), parseFloat(coordinates[1])];
+      let long = parseFloat(coordinates[1]);
+      let lat = parseFloat(coordinates[0]);
+      console.log("Coordinates found: ", long, lat);
+      feature.geometry.coordinates = [lat, long];
     }
 
 

--- a/script/main.js
+++ b/script/main.js
@@ -23,8 +23,18 @@ function parseCoordinates(string) {
   }
 }
 
-
-function fixupNullIslandCoordinates(feature) {
+/**
+ *  Attempt to detect the location from the google maps url of the feature
+ * 
+ * if the coordinates are detected as null island, try to get the coordinates from the google maps url.
+ * if the google maps url contains an address, populate the address field
+ * 
+ * if coordinates are already present, return the feature as is
+ *
+ * @param {*} feature the feature to process
+ * @returns the feature, moodified if necessary
+ */
+async function findLocationInURL(feature) {
 
   //if there isnt a null island, return the feature as is
   if (feature.geometry.coordinates[0] !== 0 || feature.geometry.coordinates[1] !== 0) {


### PR DESCRIPTION
This PR implements a best effort to intelligently replace the lat/long with available information from the google maps url to avoid otherwise-usable locations defaulting to a lat/long of 0,0 (aka null island)

The google-exported geoJSON data seems to come in one of several flavors, 

1. Lat/long present in the `geometry` section of the geoJSON, place name and address also populated, and the url only having a `cid` parameter - I suspect this may be the case for businesses that google knows about.
2. The lat/long in the `geometry` section are null, but a lat and long are present in the `q` parameter of google maps url
3. The lat/long in the `geometry` section are null, but the places address is present in the `q` parameter of google maps url

This PR handles these last two cases.

The second case is pretty trivial to handle.
The third case requires a geocoding lookup to fully convert to coordinates, and thus requires sending the address to a third party service. To do this, the OSM nominatim API is used for doing the lookups, and the lookups are only performed if the user opts-into having these addresses sent to this service prior to clicking the button to generate their converted files.


In order to introduce these steps into the process, the data pre-processing step of the code was refactored to allow for more of a pipeline-style flow, where a series of functions is called. Each function must return the data in the same format it was provided in, and can optionally modify it in some way to make the later steps easier.

Several helper functions were added as part of this but, overall, the existing code was changed as little as possible.

Testing was done on my own ~6 saved google places. Testing with a larger sampling of locations may be desireable in case there are other types that are not accounted for 

closes #2 